### PR TITLE
feat(20.11): adds a temporary image for 20.11

### DIFF
--- a/20.11-temporary/Dockerfile
+++ b/20.11-temporary/Dockerfile
@@ -1,0 +1,30 @@
+# tags=articulate/node:20.11-temporary
+# syntax=docker/dockerfile:1
+FROM node:20.11-bookworm-slim
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV SERVICE_UID 1001
+
+ARG TARGETARCH
+
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+
+RUN install_packages make && /tmp/awscli.sh && rm /tmp/awscli.sh \
+    # Create our own user and remove the node user
+    && groupadd --gid $SERVICE_UID $SERVICE_USER \
+    && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
+    && userdel -r node
+
+ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
+
+USER $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Base Node.js Docker images.
 * articulate/articulate-node:16-lambda
 * articulate/articulate-node:16-buster-slim
 
+DEPRECATED - use recommend image instead otherwise necessary
+
+* articulate/node:20.11-temporary
+
 ### articulate/node vs articulate/articulate-node
 
 `articulate/articulate-node` are the legacy Docker images. These run as root and


### PR DESCRIPTION
An issue in an upstream developer toolkit is making it incompatible with the latest node:20 images. This image should be concidered deprecated and removable at any time.

# New Image Checklist

If you're adding a new image, make sure you have done the following:

* [x] Ensure Dockerfile has a `# tag=` comment with the correct tag(s)
* [x] Tag is added to README.md
