### PR TITLE
feat: add dumb-init as entrypoint

### DIFF
--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
             build-essential python3 imagemagick retry \
-            unzip sudo jq wget curl ca-certificates \
+            unzip sudo jq wget curl ca-certificates dumb-init \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -47,4 +47,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault,
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-bootstrap
-ENTRYPOINT [ "/entrypoint" ]
+ENTRYPOINT [ "dumb-init", "--", "/entrypoint" ]

--- a/18/base/Dockerfile
+++ b/18/base/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
 
-RUN install_packages make && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
     # Create our own user and remove the node user
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
@@ -27,4 +27,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault,
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-bootstrap
-ENTRYPOINT [ "/entrypoint" ]
+ENTRYPOINT [ "dumb-init", "--", "/entrypoint" ]

--- a/20/base/Dockerfile
+++ b/20/base/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
 
-RUN install_packages make && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
     # Create our own user and remove the node user
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
@@ -27,4 +27,4 @@ WORKDIR $SERVICE_ROOT
 # Our entrypoint will pull in our environment variables from Consul and Vault,
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-bootstrap
-ENTRYPOINT [ "/entrypoint" ]
+ENTRYPOINT [ "dumb-init", "--", "/entrypoint" ]


### PR DESCRIPTION
Use dumb-init to handle zombie processes and forwarding signals.

Not including in Lambda images as it's not as easy to install and our use-case for those images isn't long running processes, so we don't need the things dumb-init gives us