### PR TITLE
fix(18-bullseye-slim): pin node to 10

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @articulate/devex-sre
+* @articulate/devex

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -qq \
     && useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
-    && npm install -g npm@latest \
+    && npm install -g npm@10 \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
     # Add node-gyp globally to avoid installation issues attempting to install from a dependency

--- a/18/base/Dockerfile
+++ b/18/base/Dockerfile
@@ -2,9 +2,7 @@
 # syntax=docker/dockerfile:1
 FROM node:18-bullseye-slim
 
-ENV SERVICE_ROOT /service
-ENV SERVICE_USER service
-ENV SERVICE_UID 1001
+ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
 
 ARG TARGETARCH
 

--- a/18/lambda/Dockerfile
+++ b/18/lambda/Dockerfile
@@ -2,10 +2,7 @@
 # syntax=docker/dockerfile:1
 FROM amazon/aws-lambda-nodejs:18
 
-ENV AWS_DEFAULT_REGION us-east-1
-ENV SERVICE_ROOT /service
-ENV SERVICE_USER service
-ENV SERVICE_UID 1001
+ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
 
 ARG TARGETARCH
 

--- a/20/lambda/Dockerfile
+++ b/20/lambda/Dockerfile
@@ -2,10 +2,7 @@
 # syntax=docker/dockerfile:1
 FROM amazon/aws-lambda-nodejs:20
 
-ENV AWS_DEFAULT_REGION us-east-1
-ENV SERVICE_ROOT /service
-ENV SERVICE_USER service
-ENV SERVICE_UID 1001
+ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
 
 ARG TARGETARCH
 

--- a/22/lambda/Dockerfile
+++ b/22/lambda/Dockerfile
@@ -2,10 +2,7 @@
 # syntax=docker/dockerfile:1
 FROM amazon/aws-lambda-nodejs:22
 
-ENV AWS_DEFAULT_REGION us-east-1
-ENV SERVICE_ROOT /service
-ENV SERVICE_USER service
-ENV SERVICE_UID 1001
+ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
 
 ARG TARGETARCH
 
@@ -30,4 +27,3 @@ WORKDIR $SERVICE_ROOT
 # and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-bootstrap
 ENTRYPOINT [ "/entrypoint" ]
-


### PR DESCRIPTION
npm 11 requires Node 20

Other changes:

* The old style of ENV key value is deprecated and is now ENV key=value