### PR TITLE
feat(24): add support for node v24

### DIFF
--- a/24/base/Dockerfile
+++ b/24/base/Dockerfile
@@ -1,0 +1,31 @@
+# tags=articulate/node:24
+# syntax=docker/dockerfile:1
+FROM node:24-bookworm-slim
+
+ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
+
+ARG TARGETARCH
+
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+
+RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
+    # Create our own user and remove the node user
+    && groupadd --gid $SERVICE_UID $SERVICE_USER \
+    && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
+    && userdel -r node \
+    # Enable Corepack
+    && npm install --global corepack@0.33.0 \
+    && corepack enable
+
+ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
+
+USER $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-bootstrap
+ENTRYPOINT [ "dumb-init", "--", "/entrypoint" ]

--- a/24/lambda/Dockerfile
+++ b/24/lambda/Dockerfile
@@ -1,0 +1,30 @@
+# tags=articulate/node:24-lambda
+# syntax=docker/dockerfile:1
+FROM amazon/aws-lambda-nodejs:24
+
+ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+ARG TARGETARCH
+
+RUN dnf -y install make zip shadow-utils \
+    # Add service user
+    && /usr/sbin/groupadd --gid $SERVICE_UID $SERVICE_USER \
+    && /usr/sbin/useradd --create-home --shell /bin/bash --uid $SERVICE_UID --gid $SERVICE_UID $SERVICE_USER \
+    # Enable Corepack
+    && npm install --global corepack@0.33.0 \
+    && corepack enable \
+    # clean up
+    && dnf -y remove shadow-utils \
+    && dnf clean all \
+    && npm cache clean --force
+
+ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
+
+USER $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Base Node.js Docker images.
 
 > 🌟 recommended image
 
+* __articulate/node:24__ 🌟
+* articulate/node:22-lambda
 * __articulate/node:22__ 🌟
 * articulate/node:22-lambda
-* __articulate/node:20__ 🌟
+* __articulate/node:20__
 * articulate/node:20-lambda
 * articulate/node:18
 * articulate/node:18-lambda


### PR DESCRIPTION
`20` is EOL/maint
`22` does not support the `--experimental-strip-types` flag for simpler TS usage and is going maint mode in October
`24` does all of it! 🥳 

https://nodejs.org/en/about/previous-releases

# New Image Checklist

If you're adding a new image, make sure you have done the following:

* [x] Ensure Dockerfile has a `# tag=` comment with the correct tag(s)
* [ ] Tag is added to README.md
